### PR TITLE
Add "lang" attribute support existing in the native Giscus

### DIFF
--- a/packages/@shared/types.ts
+++ b/packages/@shared/types.ts
@@ -10,6 +10,7 @@ type Giscus = {
   theme?: Theme
   reactionsEnabled?: BooleanString
   emitMetadata?: BooleanString
+  lang?: Lang
 }
 
 type BooleanString = '0' | '1'
@@ -30,5 +31,21 @@ type Theme =
   | 'preferred_color_scheme'
   | 'transparent_dark'
   | `https://${string}`
+
+type Lang =
+  | 'en'
+  | 'fr'
+  | 'de'
+  | 'gsw'
+  | 'es'
+  | 'it'
+  | 'ja'
+  | 'ko'
+  | 'pl'
+  | 'id'
+  | 'ro'
+  | 'zh-CN'
+  | 'zh-TW'
+  | string
 
 export type { GiscusProps, Giscus, Session, Repo, Mapping, Theme }

--- a/packages/@shared/util.ts
+++ b/packages/@shared/util.ts
@@ -26,6 +26,7 @@ export function getIframeSrc({
   theme = 'light',
   reactionsEnabled = '1',
   emitMetadata = '0',
+  lang = 'en',
   session,
   origin = location.href
 }: Giscus & Session & { origin?: string }) {
@@ -69,7 +70,7 @@ export function getIframeSrc({
       break
   }
 
-  return `${GISCUS_ORIGIN}/widget?${new URLSearchParams(params)}`
+  return `${GISCUS_ORIGIN}/${lang}/widget?${new URLSearchParams(params)}`
 }
 
 export function addDefaultStyles() {

--- a/packages/react/_debug/main.tsx
+++ b/packages/react/_debug/main.tsx
@@ -14,6 +14,7 @@ ReactDOM.render(
       reactionsEnabled="1"
       emitMetadata="0"
       theme="light"
+      lang="en"
     />
   </React.StrictMode>,
   document.getElementById('root')

--- a/packages/react/lib/Giscus.tsx
+++ b/packages/react/lib/Giscus.tsx
@@ -76,7 +76,8 @@ export default function Giscus({
   term,
   theme,
   reactionsEnabled,
-  emitMetadata
+  emitMetadata,
+  lang
 }: GiscusProps) {
   const [isMounted, setIsMounted] = useState(false)
   useEffect(() => setIsMounted(true), [])
@@ -93,6 +94,7 @@ export default function Giscus({
       theme={theme}
       reactionsEnabled={reactionsEnabled}
       emitMetadata={emitMetadata}
+      lang={lang}
     />
   )
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -35,7 +35,8 @@
     "@types/react-dom": "^17.0.0",
     "@vitejs/plugin-react-refresh": "^1.3.1",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "prop-types": "^15.7.2"
   },
   "author": {
     "name": "laymonage",

--- a/packages/svelte/_debug/App.svelte
+++ b/packages/svelte/_debug/App.svelte
@@ -13,5 +13,6 @@
     reactionsEnabled="1"
     emitMetadata="0"
     theme="light"
+    lang="en"
   />
 </main>

--- a/packages/svelte/lib/Giscus.svelte
+++ b/packages/svelte/lib/Giscus.svelte
@@ -18,6 +18,7 @@
   export let categoryId: GiscusProps['categoryId'] = ''
   export let mapping: GiscusProps['mapping']
   export let term: GiscusProps['term'] = ''
+  export let lang: GiscusProps['lang'] = 'en'
   export let theme: GiscusProps['theme'] = 'light'
   export let reactionsEnabled: GiscusProps['reactionsEnabled'] = '1'
   export let emitMetadata: GiscusProps['emitMetadata'] = '0'
@@ -30,10 +31,11 @@
     categoryId,
     mapping,
     term,
+    lang,
     theme,
     reactionsEnabled,
     emitMetadata,
-    session
+    session,
   })
 
   onMount(() => {

--- a/packages/vue/_debug/App.vue
+++ b/packages/vue/_debug/App.vue
@@ -9,6 +9,7 @@
     reactionsEnabled="1"
     emitMetadata="0"
     theme="light"
+    lang="en"
   />
 </template>
 

--- a/packages/vue/lib/Giscus.tsx
+++ b/packages/vue/lib/Giscus.tsx
@@ -35,6 +35,10 @@ const Giscus = defineComponent({
       required: true
     },
     term: String as PropType<GiscusProps['term']>,
+    lang: {
+      type: String as PropType<GiscusProps['lang']>,
+      default: 'en'
+    },
     theme: {
       type: String as PropType<GiscusProps['theme']>,
       default: 'light'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4369,7 +4369,7 @@ longest@^2.0.1:
   resolved "https://registry.yarnpkg.com/longest/-/longest-2.0.1.tgz#781e183296aa94f6d4d916dc335d0d17aefa23f8"
   integrity sha1-eB4YMpaqlPbU2RbcM10NF676I/g=
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -5527,6 +5527,15 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
+prop-types@^15.7.2:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
+
 property-information@^5.1.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-5.6.0.tgz#61675545fb23002f245c6540ec46077d4da3ed69"
@@ -5740,6 +5749,11 @@ react-dom@^17.0.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     scheduler "^0.20.2"
+
+react-is@^16.13.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 react-refresh@^0.10.0:
   version "0.10.0"


### PR DESCRIPTION
Hi Sage!

Thank you for your good work on giscus and giscus-component libraries! 🤗

One thing, I've seen in the giscus component package (and this [issue](https://github.com/giscus/giscus-component/issues/15) mentioned) was the lack of `lang` option available in the "no-framework version of giscus".

Because of that, I've added it to all packages (React, Vue and Svelte), tested and opened this PR. I hope it will be useful!

In addition, as I know, `yarn` does not install peerDependencies as `npm` does from version 7.0 and because of that, I wasn't able to run the package dev server without adding `prop-types` in React giscus component as classic devDependency. 

If this is a case, adding it as a dependency should be useful. If not of course, let me know how I should run de environment and I will also change the PR content (or you can do it either) 😌

Have an awesome day!