### PR TITLE
fix: respect the current theme by avoiding the color-scheme

### DIFF
--- a/web/src/giscus.ts
+++ b/web/src/giscus.ts
@@ -24,6 +24,7 @@ export class GiscusWidget extends LitElement {
     iframe {
       width: 100%;
       border: none;
+      color-scheme: normal;
     }
   `;
 


### PR DESCRIPTION
If we use the `dark` or any variations of the theme in dark mode, this will happen:

![iframe without color scheme and dark mode](https://user-images.githubusercontent.com/31737273/161444244-65dcb981-087a-4628-b09d-0c5f18aaaf5a.png)

But if we add `color-scheme: none;` we avoid having problems with the embedded iframe and their styles:

![color-scheme showcase in dark mode](https://user-images.githubusercontent.com/31737273/161444277-0fd65e4f-8dc1-48b6-a831-642e86db8e16.png)

![color-scheme showcase in light mode](https://user-images.githubusercontent.com/31737273/161444292-48c7b150-34af-4826-bbdf-4b76cc748546.png)
