### PR TITLE
Remove <main>

### DIFF
--- a/svelte/src/lib/Giscus.svelte
+++ b/svelte/src/lib/Giscus.svelte
@@ -26,20 +26,18 @@
   export let loading: Loading = 'eager';
 </script>
 
-<main>
-  <giscus-widget
-    {id}
-    {repo}
-    repoid={repoId}
-    {category}
-    categoryid={categoryId}
-    {mapping}
-    {term}
-    reactionsenabled={reactionsEnabled}
-    emitmetadata={emitMetadata}
-    inputposition={inputPosition}
-    {theme}
-    {lang}
-    {loading}
-  />
-</main>
+<giscus-widget
+  {id}
+  {repo}
+  repoid={repoId}
+  {category}
+  categoryid={categoryId}
+  {mapping}
+  {term}
+  reactionsenabled={reactionsEnabled}
+  emitmetadata={emitMetadata}
+  inputposition={inputPosition}
+  {theme}
+  {lang}
+  {loading}
+/>


### PR DESCRIPTION
Right now the svelte component will include `<main>` when you use it, which doesn't make sense at all.

The `<main>` for the demo should be added else where.