### PR TITLE
common: Update giscus to 1.0.4 and bump version to 2.0.4

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@giscus/react",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@giscus/react",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "dependencies": {
         "giscus": "^1.0.3"
       },

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@giscus/react",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
   "types": "dist/index.d.ts",

--- a/svelte/package-lock.json
+++ b/svelte/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@giscus/svelte",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@giscus/svelte",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "dependencies": {
         "giscus": "^1.0.3"
       },

--- a/svelte/package.json
+++ b/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@giscus/svelte",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "types": "./index.d.ts",
   "repository": {
     "type": "git",

--- a/vue/package-lock.json
+++ b/vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@giscus/vue",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@giscus/vue",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "dependencies": {
         "giscus": "^1.0.3"
       },

--- a/vue/package.json
+++ b/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@giscus/vue",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "main": "dist/giscus.cjs.js",
   "module": "dist/index.es.js",
   "types": "dist/index.d.ts",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "giscus",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "giscus",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "lit": "^2.2.3"

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "giscus",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "type": "module",
   "main": "dist/giscus.es.js",
   "module": "dist/giscus.es.js",


### PR DESCRIPTION
Note: I forgot to bump the giscus version in each package to 1.0.4 before releasing 🤦

There's no significant changes from 1.0.3, though. You can update it manually in your package if you really need it. I'll re-sync the versions in 1.0.5/2.0.5.