### PR TITLE
web: Fix incorrect module path and bump to v1.1.1

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "giscus",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "giscus",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "lit": "^2.2.8"

--- a/web/package.json
+++ b/web/package.json
@@ -2,12 +2,12 @@
   "name": "giscus",
   "version": "1.1.0",
   "type": "module",
-  "main": "dist/giscus.es.js",
-  "module": "dist/giscus.es.js",
+  "main": "dist/giscus.js",
+  "module": "dist/giscus.js",
   "exports": {
     ".": {
       "types": "./types/giscus.d.ts",
-      "import": "./dist/giscus.es.js"
+      "import": "./dist/giscus.js"
     }
   },
   "types": "types/giscus.d.ts",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "giscus",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "main": "dist/giscus.js",
   "module": "dist/giscus.js",


### PR DESCRIPTION
Turns out Vite now does not append the module type to the file name anymore for some reason... *sigh*.