### PR TITLE
build es modules with .mjs extension

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@giscus/react",
   "version": "2.2.2",
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.es.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "require": "./dist/index.cjs.js",
-      "import": "./dist/index.es.js"
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.mjs"
     }
   },
   "files": [

--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -12,7 +12,10 @@ export default defineConfig({
     lib: {
       entry: resolve(__dirname, 'src/lib/index.ts'),
       formats: ['cjs', 'es'],
-      fileName: (format) => `index.${format}.js`,
+      fileName: (format) => ({
+        cjs: 'index.cjs',
+        es: 'index.mjs',
+      }[format]),
     },
     rollupOptions: {
       external: ['react', 'react-dom', 'react/jsx-runtime'],

--- a/vue/package.json
+++ b/vue/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@giscus/vue",
   "version": "2.2.2",
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.es.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "require": "./dist/index.cjs.js",
-      "import": "./dist/index.es.js"
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.mjs"
     }
   },
   "files": [

--- a/vue/vite.config.ts
+++ b/vue/vite.config.ts
@@ -17,7 +17,10 @@ export default defineConfig({
     lib: {
       entry: resolvePath('src/lib/index.ts'),
       formats: ['cjs', 'es'],
-      fileName: (format) => `index.${format}.js`,
+      fileName: (format) => ({
+        cjs: 'index.cjs',
+        es: 'index.mjs',
+      }[format]),
     },
     rollupOptions: {
       external: ['vue'],

--- a/web/package.json
+++ b/web/package.json
@@ -2,12 +2,12 @@
   "name": "giscus",
   "version": "1.2.2",
   "type": "module",
-  "main": "dist/giscus.js",
-  "module": "dist/giscus.js",
+  "main": "dist/giscus.mjs",
+  "module": "dist/giscus.mjs",
   "exports": {
     ".": {
       "types": "./types/giscus.d.ts",
-      "import": "./dist/giscus.js"
+      "import": "./dist/giscus.mjs"
     }
   },
   "types": "types/giscus.d.ts",

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     lib: {
       entry: 'src/giscus.ts',
       formats: ['es'],
+      fileName: () => 'giscus.mjs',
     },
     rollupOptions: {
       external: /^lit/,


### PR DESCRIPTION
get rid of `SyntaxError: Cannot use import statement outside a module`