### PR TITLE
react: Fix build with next/webpack + react@<18.0.0

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@giscus/react",
   "version": "2.2.3",
-  "main": "dist/index.cjs",
-  "module": "dist/index.mjs",
+  "main": "dist/index.js",
+  "module": "dist/wrapper.mjs",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "require": "./dist/index.cjs",
-      "import": "./dist/index.mjs"
+      "require": "./dist/index.js",
+      "import": "./dist/wrapper.mjs"
     }
   },
   "files": [

--- a/react/vite.config.ts
+++ b/react/vite.config.ts
@@ -7,15 +7,12 @@ const resolvePath = (str: string) => resolve(__dirname, str);
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), wrapper()],
   build: {
     lib: {
       entry: resolve(__dirname, 'src/lib/index.ts'),
-      formats: ['cjs', 'es'],
-      fileName: (format) => ({
-        cjs: 'index.cjs',
-        es: 'index.mjs',
-      }[format]),
+      formats: ['cjs'],
+      fileName: 'index',
     },
     rollupOptions: {
       external: ['react', 'react-dom', 'react/jsx-runtime'],
@@ -37,3 +34,16 @@ export default defineConfig({
     },
   },
 });
+
+function wrapper() {
+  return {
+    name: 'wrapper',
+    generateBundle() {
+      this.emitFile({
+        type: 'asset',
+        fileName: 'wrapper.mjs',
+        source: `import module from './index.js';\n\nexport default module;`,
+      });
+    },
+  };
+}


### PR DESCRIPTION
build only cjs to be compatible with `react@<18.0.0`, and use a wrapper to support esm.

## About this PR

This is going to fix #782 .

## What's the problem

In `@giscus/react@2.2.2`, next/webpack will resolve `@giscus/react` to only `./dist/index.cjs.js` whatever you write `require` or `import` in your project, which escapes the issue.

(`console.log` was added manually for debugging)
<img width="2032" alt="image" src="https://user-images.githubusercontent.com/11156420/202844088-c880ec0d-c950-475b-8a37-9d4d5156d78c.png">

But in `@giscus/react@2.2.3`, with `.mjs` extension for esm `import` configured, `@giscus/react` will be resolved to `./dist/index.cjs` when using `require`, and `./dist/index.mjs` when using `import`.

`./dist/index.mjs`  imports `react/jsx-runtime`which triggers this issue from react https://github.com/facebook/react/issues/20235 .

<img width="2032" alt="image" src="https://user-images.githubusercontent.com/11156420/202844461-a4422c96-5fbe-41dd-a775-3876b4de70b6.png">

## The workaround

To be compatible with `react@<18.0.0`, we should only `require` the `react/jsx-runtime` (no esm `import`) in our build products.

To be esm compatible, we can use a wrapper mjs that imports the cjs product. Official approach here https://nodejs.org/api/packages.html#approach-1-use-an-es-module-wrapper

So I wrote a vite plugin to emit the wrapper file.

(`console.log` was added manually for debugging)
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/11156420/202845451-8fef9ce4-452a-428e-ab4b-1b8201f5d7df.png">

Thus, everything works fine!

## My testing environment

node: 16.18.1
npm: 8.19.2
next: 12.3.3
react: 17.0.2