### PR TITLE
Support COEP with credentialless iframe

### DIFF
--- a/web/src/giscus.ts
+++ b/web/src/giscus.ts
@@ -369,6 +369,7 @@ export class GiscusWidget extends LitElement {
   render() {
     return html`
       <iframe
+        credentialless
         title="Comments"
         scrolling="no"
         class="loading"


### PR DESCRIPTION
When embedding the iframe in a site that sets COEP headers, the iframe refuses to load in chrome and Firefox. Adding the credentialless attribute to the iframe allows the iframe to load in chrome, and soon, Firefox. 

https://developer.mozilla.org/en-US/docs/Web/Security/IFrame_credentialless